### PR TITLE
refactor: thin-caller agent workflows (#335)

### DIFF
--- a/.github/workflows/agent-issue-triage.yml
+++ b/.github/workflows/agent-issue-triage.yml
@@ -1,0 +1,12 @@
+name: "Agent: Issue Triage"
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    uses: eqdmc/.github/.github/workflows/agent-issue-triage.yml@main
+    with:
+      issue-number: ${{ github.event.issue.number }}
+    secrets: inherit

--- a/.github/workflows/agent-maintenance.yml
+++ b/.github/workflows/agent-maintenance.yml
@@ -1,0 +1,11 @@
+name: "Agent: Weekly Maintenance"
+
+on:
+  schedule:
+    - cron: "0 2 * * 0"
+  workflow_dispatch:
+
+jobs:
+  maintenance:
+    uses: eqdmc/.github/.github/workflows/agent-maintenance.yml@main
+    secrets: inherit

--- a/.github/workflows/agent-process-issue.yml
+++ b/.github/workflows/agent-process-issue.yml
@@ -1,0 +1,13 @@
+name: "Agent: Process Issue"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'agent-work'
+    uses: eqdmc/.github/.github/workflows/agent-process-issue.yml@main
+    with:
+      issue-number: ${{ github.event.issue.number }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Replaces full agent workflow copies with thin callers. All logic lives in `eqdmc/.github/.github/workflows/`.

Changes per file:
- `agent-process-issue.yml`: 30+ lines → 10 lines
- `agent-issue-triage.yml`: 30+ lines → 9 lines
- `agent-maintenance.yml`: 30+ lines → 10 lines
- `ci.yml`: auto-detects Python + Node, no inputs needed

To change prompts, models, or tools: one PR to `eqdmc/.github`.

Closes #335 (partial)

Co-Authored-By: Claude <noreply@anthropic.com>