### PR TITLE
chore: add ci-self-hosted.yml from org SSOT

### DIFF
--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -1,0 +1,18 @@
+# Deployed from eqdmc/.github — calls reusable self-hosted CI.
+# Uses eqdmc-build runner group for faster CI.
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: eqdmc/.github/.github/workflows/ci-self-hosted.yml@61abcf66189f5007c82a57ecb5e9955afdd953ad
+    secrets: inherit


### PR DESCRIPTION
Adds the self-hosted CI workflow from eqdmc/.github SSOT.
            
This enables self-hosted runner CI for this repo. The runner pool
is managed centrally via eqdmc-build runner group.